### PR TITLE
Real-time geo-position updates

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -43,6 +43,7 @@ class App extends Component {
         lat: 50.1034007,
         lng: 14.4483626
       },
+      positionWatchId: null,
       center: {
         lat: 50.1034007,
         lng: 14.4483626
@@ -55,14 +56,28 @@ class App extends Component {
 
   componentWillMount() {
     if (navigator && navigator.geolocation) {
-      navigator.geolocation.getCurrentPosition(
-        res => {
-          this.updateCoords(res.coords.latitude, res.coords.longitude)
-        },
-        err => {
-          geolocationErrorHandler(err)
-        }
-      )
+      this.watchPosition()
+    }
+  }
+
+  watchPosition() {
+    var watchId = navigator.geolocation.watchPosition(
+      res => {
+        this.updateCoords(res.coords.latitude, res.coords.longitude)
+      },
+      err => {
+        geolocationErrorHandler(err)
+      }
+    )
+    this.setState({positionWatchId: watchId});
+    console.log("Watching position");
+  }
+
+  stopWatchingPosition() {
+    if (this.state.positionWatchId != null) {
+      navigator.geolocation.clearWatch(this.state.positionWatchId)
+      this.setState({positionWatchId: null})
+      console.log("Position watch stopped");
     }
   }
 
@@ -73,6 +88,7 @@ class App extends Component {
         lng
       }
     })
+    console.log("New position:", this.state.position)
   }
 
   addItem = (event) => {


### PR DESCRIPTION
This should allow us to update the client position in real-time. Might be problematic on some Wifi networks (there's no error, the callback is never called for some reason and screen get stuck in the initial coords).

To stop updating the client current position, we can call stopWatchingPosition().
To restore the position updates watchPosition() can be called.

No UI.